### PR TITLE
Add NPM and GitHub Packages publish action (#47)

### DIFF
--- a/ _config.yml
+++ b/ _config.yml
@@ -1,1 +1,0 @@
-theme: minima

--- a/.github/workflows/npm-publish-dry-run.yml
+++ b/.github/workflows/npm-publish-dry-run.yml
@@ -2,11 +2,12 @@
 # GitHub Packages and NPM when a release is created.
 # For more information see: https://docs.github.com/en/actions/publishing-packages/publishing-nodejs-packages
 
-name: Remote Deployment
+name: Remote Deployment Dry Run
 
 on:
-  release:
-    types: [published]
+  push:
+    branches:
+      - develop
 
 jobs:
   build:
@@ -31,7 +32,7 @@ jobs:
           registry-url: https://npm.pkg.github.com/
           scope: ${{ vars.USERNAME }}
       - run: npm ci
-      - run: npm publish
+      - run: npm publish --dry-run
         env:
           NODE_AUTH_TOKEN: ${{ secrets.RO_GITHUB }}
 
@@ -45,6 +46,6 @@ jobs:
           node-version: 16
           registry-url: https://registry.npmjs.org/
       - run: npm ci
-      - run: npm publish
+      - run: npm publish --dry-run
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_KEY }}

--- a/.github/workflows/npm-publish-dry-run.yml
+++ b/.github/workflows/npm-publish-dry-run.yml
@@ -18,8 +18,7 @@ jobs:
         with:
           node-version: 16
       - run: yarn install --frozen-lockfile
-      - run: yarn lint
-      - run: yarn test
+      - run: yarn test-ci
 
   publish-github:
     needs: build

--- a/.github/workflows/npm-publish-dry-run.yml
+++ b/.github/workflows/npm-publish-dry-run.yml
@@ -18,7 +18,9 @@ jobs:
         with:
           node-version: 16
       - run: yarn install --frozen-lockfile
-      - run: yarn test-ci
+      - run: yarn build
+        env:
+          NODE_ENV: 'production'
 
   publish-github:
     needs: build

--- a/.github/workflows/npm-publish-dry-run.yml
+++ b/.github/workflows/npm-publish-dry-run.yml
@@ -17,9 +17,9 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: 16
-      - run: npm ci
-      - run: npm lint
-      - run: npm test
+      - run: yarn install --frozen-lockfile
+      - run: yarn lint
+      - run: yarn test
 
   publish-github:
     needs: build
@@ -31,7 +31,7 @@ jobs:
           node-version: 16
           registry-url: https://npm.pkg.github.com/
           scope: ${{ vars.USERNAME }}
-      - run: npm ci
+      - run: yarn install --frozen-lockfile
       - run: npm publish --dry-run
         env:
           NODE_AUTH_TOKEN: ${{ secrets.RO_GITHUB }}
@@ -45,7 +45,7 @@ jobs:
         with:
           node-version: 16
           registry-url: https://registry.npmjs.org/
-      - run: npm ci
+      - run: yarn install --frozen-lockfile
       - run: npm publish --dry-run
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_KEY }}

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -16,9 +16,10 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: 16
-      - run: npm ci
-      - run: npm lint
-      - run: npm test
+      - run: yarn install --frozen-lockfile
+      - run: yarn build
+        env:
+          NODE_ENV: 'production'
 
   publish-github:
     needs: build
@@ -30,7 +31,7 @@ jobs:
           node-version: 16
           registry-url: https://npm.pkg.github.com/
           scope: ${{ vars.USERNAME }}
-      - run: npm ci
+      - run: yarn install --frozen-lockfile
       - run: npm publish
         env:
           NODE_AUTH_TOKEN: ${{ secrets.RO_GITHUB }}
@@ -44,7 +45,7 @@ jobs:
         with:
           node-version: 16
           registry-url: https://registry.npmjs.org/
-      - run: npm ci
+      - run: yarn install --frozen-lockfile
       - run: npm publish
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_KEY }}

--- a/.prettierrc
+++ b/.prettierrc
@@ -16,7 +16,6 @@
     {
       "files": ["*.json"],
       "options": {
-        "tabWidth": 4,
         "singleQuote": false
       }
     }

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,4 +1,4 @@
-export default {
+module.exports = {
   preset: 'ts-jest',
   testEnvironment: 'node',
   moduleFileExtensions: ['ts', 'tsx', 'json', 'node', 'js'],
@@ -10,7 +10,7 @@ export default {
     }]
   },
   coverageDirectory: '../coverage',
-  testPathIgnorePatterns: ['/node_modules/', '__mocks__'],
+  testPathIgnorePatterns: ['/node_modules/', '__mocks__', '.js'],
   collectCoverageFrom: [
     '**/*.ts',
     '!main/**/*'

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "express-winston": "^4.2.0",
     "form-data": "^4.0.0",
     "jsonwebtoken": "^9.0.0",
+    "openai": "^3.3.0",
     "sqlite3": "^5.1.6",
     "stringify": "^5.2.0",
     "winston": "^3.9.0"

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Secure OpenAI Key Proxy (SOAKP) facilitates secure usage of the OpenAI API key through a proxy-like application.",
   "repository": {
     "type": "git",
-    "url": "git@github.com:lehcode/soakp.git"
+    "url": "https://github.com/lehcode/soakp.git"
   },
   "keywords": [
     "soakp",
@@ -28,7 +28,7 @@
     "dev": "NODE_OPTIONS='--trace-warnings' npx ts-node server.ts",
     "serve": "node -r ts-node/register server.ts",
     "test": "NODE_ENV='testing' jest",
-    "ci": "jest --ci"
+    "test-ci": "NODE_ENV='testing' jest --ci"
   },
   "files": [
     "**/*.ts",
@@ -44,7 +44,6 @@
     "express-winston": "^4.2.0",
     "form-data": "^4.0.0",
     "jsonwebtoken": "^9.0.0",
-    "openai": "^3.2.1",
     "sqlite3": "^5.1.6",
     "stringify": "^5.2.0",
     "winston": "^3.9.0"
@@ -64,7 +63,6 @@
     "@typescript-eslint/parser": "^5.59.8",
     "babel-jest": "^29.5.0",
     "babel-plugin-transform-remove-console": "^6.9.4",
-    "browserslist": "^4.21.5",
     "eslint": "^8.42.0",
     "eslint-config-prettier": "^8.8.0",
     "eslint-plugin-prettier": "^4.2.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2088,6 +2088,13 @@ asynckit@^0.4.0:
   resolved "https://registry.yarnpkg.com/asynckit/-/asynckit-0.4.0.tgz#c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"
   integrity sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==
 
+axios@^0.26.0:
+  version "0.26.1"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-0.26.1.tgz#1ede41c51fcf51bbbd6fd43669caaa4f0495aaa9"
+  integrity sha512-fPwcX4EvnSHuInCMItEhAGnaSEXRBjtzh9fOtsE6E1G6p7vl7edEeZe11QHf18+6+9gR5PbKV/sGKNaD8YaMeA==
+  dependencies:
+    follow-redirects "^1.14.8"
+
 axios@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/axios/-/axios-1.4.0.tgz#38a7bf1224cd308de271146038b551d725f0be1f"
@@ -3099,7 +3106,7 @@ fn.name@1.x.x:
   resolved "https://registry.yarnpkg.com/fn.name/-/fn.name-1.1.0.tgz#26cad8017967aea8731bc42961d04a3d5988accc"
   integrity sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw==
 
-follow-redirects@^1.15.0:
+follow-redirects@^1.14.8, follow-redirects@^1.15.0:
   version "1.15.2"
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.2.tgz#b460864144ba63f2681096f274c4e57026da2c13"
   integrity sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==
@@ -4448,6 +4455,14 @@ onetime@^5.1.2:
   integrity sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==
   dependencies:
     mimic-fn "^2.1.0"
+
+openai@^3.3.0:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/openai/-/openai-3.3.0.tgz#a6408016ad0945738e1febf43f2fccca83a3f532"
+  integrity sha512-uqxI/Au+aPRnsaQRe8CojU0eCR7I0mBiKjD3sNMzY6DaC1ZVrc85u98mtJW6voDug8fgGN+DIZmTDxTthxb7dQ==
+  dependencies:
+    axios "^0.26.0"
+    form-data "^4.0.0"
 
 optionator@^0.9.1:
   version "0.9.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1258,20 +1258,20 @@
     minimatch "^3.1.2"
     strip-json-comments "^3.1.1"
 
-"@eslint/js@8.41.0":
-  version "8.41.0"
-  resolved "https://registry.yarnpkg.com/@eslint/js/-/js-8.41.0.tgz#080321c3b68253522f7646b55b577dd99d2950b3"
-  integrity sha512-LxcyMGxwmTh2lY9FwHPGWOHmYFCZvbrFCBZL4FzSSsxsRPuhrYUg/49/0KDfW8tnIEaEHtfmn6+NPN+1DqaNmA==
+"@eslint/js@8.43.0":
+  version "8.43.0"
+  resolved "https://registry.yarnpkg.com/@eslint/js/-/js-8.43.0.tgz#559ca3d9ddbd6bf907ad524320a0d14b85586af0"
+  integrity sha512-s2UHCoiXfxMvmfzqoN+vrQ84ahUSYde9qNO1MdxmoEhyHWsfmwOpFlwYV+ePJEVc7gFnATGUi376WowX1N7tFg==
 
 "@gar/promisify@^1.0.1":
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/@gar/promisify/-/promisify-1.1.3.tgz#555193ab2e3bb3b6adc3d551c9c030d9e860daf6"
   integrity sha512-k2Ty1JcVojjJFwrg/ThKi2ujJ7XNLYaFGNB/bWT9wGR+oSMJHMa5w+CUq6p/pVrKeNNgA7pCqEcjSnHVoqJQFw==
 
-"@humanwhocodes/config-array@^0.11.8":
-  version "0.11.8"
-  resolved "https://registry.yarnpkg.com/@humanwhocodes/config-array/-/config-array-0.11.8.tgz#03595ac2075a4dc0f191cc2131de14fbd7d410b9"
-  integrity sha512-UybHIJzJnR5Qc/MsD9Kr+RpO2h+/P1GhOwdiLPXK5TWk5sgTdu88bTD9UP+CKbPPh5Rni1u0GjAdYQLemG8g+g==
+"@humanwhocodes/config-array@^0.11.10":
+  version "0.11.10"
+  resolved "https://registry.yarnpkg.com/@humanwhocodes/config-array/-/config-array-0.11.10.tgz#5a3ffe32cc9306365fb3fd572596cd602d5e12d2"
+  integrity sha512-KVVjQmNUepDVGXNuoRRdmmEjruj0KfiGSbS8LVc12LMsWDQzRXJ0qdhN8L8uUigKpfEHRhlaQFY0ib1tnUbNeQ==
   dependencies:
     "@humanwhocodes/object-schema" "^1.2.1"
     debug "^4.1.1"
@@ -2088,13 +2088,6 @@ asynckit@^0.4.0:
   resolved "https://registry.yarnpkg.com/asynckit/-/asynckit-0.4.0.tgz#c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"
   integrity sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==
 
-axios@^0.26.0:
-  version "0.26.1"
-  resolved "https://registry.yarnpkg.com/axios/-/axios-0.26.1.tgz#1ede41c51fcf51bbbd6fd43669caaa4f0495aaa9"
-  integrity sha512-fPwcX4EvnSHuInCMItEhAGnaSEXRBjtzh9fOtsE6E1G6p7vl7edEeZe11QHf18+6+9gR5PbKV/sGKNaD8YaMeA==
-  dependencies:
-    follow-redirects "^1.14.8"
-
 axios@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/axios/-/axios-1.4.0.tgz#38a7bf1224cd308de271146038b551d725f0be1f"
@@ -2795,16 +2788,16 @@ eslint-visitor-keys@^3.3.0, eslint-visitor-keys@^3.4.1:
   resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-3.4.1.tgz#c22c48f48942d08ca824cc526211ae400478a994"
   integrity sha512-pZnmmLwYzf+kWaM/Qgrvpen51upAktaaiI01nsJD/Yr3lMOdNtq0cxkrrg16w64VtisN6okbs7Q8AfGqj4c9fA==
 
-eslint@^8.41.0:
-  version "8.41.0"
-  resolved "https://registry.yarnpkg.com/eslint/-/eslint-8.41.0.tgz#3062ca73363b4714b16dbc1e60f035e6134b6f1c"
-  integrity sha512-WQDQpzGBOP5IrXPo4Hc0814r4/v2rrIsB0rhT7jtunIalgg6gYXWhRMOejVO8yH21T/FGaxjmFjBMNqcIlmH1Q==
+eslint@^8.42.0:
+  version "8.43.0"
+  resolved "https://registry.yarnpkg.com/eslint/-/eslint-8.43.0.tgz#3e8c6066a57097adfd9d390b8fc93075f257a094"
+  integrity sha512-aaCpf2JqqKesMFGgmRPessmVKjcGXqdlAYLLC3THM8t5nBRZRQ+st5WM/hoJXkdioEXLLbXgclUpM0TXo5HX5Q==
   dependencies:
     "@eslint-community/eslint-utils" "^4.2.0"
     "@eslint-community/regexpp" "^4.4.0"
     "@eslint/eslintrc" "^2.0.3"
-    "@eslint/js" "8.41.0"
-    "@humanwhocodes/config-array" "^0.11.8"
+    "@eslint/js" "8.43.0"
+    "@humanwhocodes/config-array" "^0.11.10"
     "@humanwhocodes/module-importer" "^1.0.1"
     "@nodelib/fs.walk" "^1.2.8"
     ajv "^6.10.0"
@@ -3106,7 +3099,7 @@ fn.name@1.x.x:
   resolved "https://registry.yarnpkg.com/fn.name/-/fn.name-1.1.0.tgz#26cad8017967aea8731bc42961d04a3d5988accc"
   integrity sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw==
 
-follow-redirects@^1.14.8, follow-redirects@^1.15.0:
+follow-redirects@^1.15.0:
   version "1.15.2"
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.2.tgz#b460864144ba63f2681096f274c4e57026da2c13"
   integrity sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==
@@ -4455,14 +4448,6 @@ onetime@^5.1.2:
   integrity sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==
   dependencies:
     mimic-fn "^2.1.0"
-
-openai@^3.2.1:
-  version "3.2.1"
-  resolved "https://registry.yarnpkg.com/openai/-/openai-3.2.1.tgz#1fa35bdf979cbde8453b43f2dd3a7d401ee40866"
-  integrity sha512-762C9BNlJPbjjlWZi4WYK9iM2tAVAv0uUp1UmI34vb0CN5T2mjB/qM6RYBmNKMh/dN9fC+bxqPwWJZUTWW052A==
-  dependencies:
-    axios "^0.26.0"
-    form-data "^4.0.0"
 
 optionator@^0.9.1:
   version "0.9.1"


### PR DESCRIPTION
* feat: add remote deployment to GitHub Packages and NPM

Added a new workflow to deploy releases to GitHub Packages and NPM. The workflow runs tests using node on release creation and publishes the package to both GitHub Packages and NPM. The workflow also includes linting and testing steps. The `NODE_AUTH_TOKEN` environment variable is used to authenticate the deployment to both GitHub Packages and NPM.

* feat: add push trigger for publish branch in `npm-publish.yml` file

* build: enable publishing to NPM and GitHub Packages

This commit updates the `.github/workflows/npm-publish.yml` file to remove the `push` trigger for the `publish` branch and adds a `release` trigger for `published` types. It also removes the `--dry-run` flag from the `npm publish` command, allowing for actual publishing to occur.

A new workflow is added in `.github/workflows/npm-publish-dry-run.yml`, which performs a dry run of the publishing process on the `develop` branch. This workflow runs `npm lint` and `npm test` in addition to the `npm publish --dry-run` command and is intended for use as a pre-publish check.

Both workflows now use Node.js version 16 and have been tested on Ubuntu.